### PR TITLE
Fix documentation, don't emit 'connection' if the socket is closed and improve path behaviour

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -12,7 +12,6 @@ This class is a WebSocket server. It is an `EventEmitter`.
   * `server` http.Server
   * `verifyClient` Function
   * `handleProtocols` Function
-  * `path` String
   * `noServer` Boolean
   * `disableHixie` Boolean
   * `clientTracking` Boolean

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -29,7 +29,7 @@ Either `port` or `server` must be provided, otherwise you might enable
 `verifyClient` can be used in two different ways. If it is provided with two arguments then those are:
 * `info` Object:
   * `origin` String: The value in the Origin header indicated by the client.
-  * `req` http.ClientRequest: The client HTTP GET request.
+  * `req` http.IncomingMessage: The client HTTP GET request.
   * `secure` Boolean: `true` if `req.connection.authorized` or `req.connection.encypted` is set.
 * `cb` Function: A callback that must be called by the user upon inspection of the `info` fields. Arguments in this callback are:
   * `result` Boolean: Whether the user accepts or not the handshake.
@@ -55,7 +55,7 @@ If `handleProtocols` is not set then the handshake is accepted regardless the va
 
 ### server.close()
 
-Close the server and terminate all clients
+Close the server and terminate all clients.
 
 ### server.handleUpgrade(request, socket, upgradeHead, callback)
 
@@ -121,7 +121,11 @@ The WebSocket protocol version used for this connection, `8`, `13` or `hixie-76`
 
 ### websocket.url
 
-The URL of the WebSocket server (only for clients)
+The URL of the WebSocket server (only for clients).
+
+### websocket.upgradeReq
+
+The received `http.IncomingMessage` containing the HTTP GET request (only for servers).
 
 ### websocket.supports
 
@@ -129,24 +133,24 @@ Describes the feature of the used protocol version. E.g. `supports.binary` is a 
 
 ### websocket.close([code], [data])
 
-Gracefully closes the connection, after sending a description message
+Gracefully closes the connection, after sending a description message.
 
 ### websocket.pause()
 
-Pause the client stream
+Pause the client stream.
 
 ### websocket.ping([data], [options], [dontFailWhenClosed])
 
-Sends a ping. `data` is sent, `options` is an object with members `mask` and `binary`. `dontFailWhenClosed` indicates whether or not to throw if the connection isnt open.
+Sends a ping. `data` is sent, `options` is an object with members `mask` and `binary`. `dontFailWhenClosed` indicates whether or not to throw if the connection is not open.
 
 ### websocket.pong([data], [options], [dontFailWhenClosed])
 
-Sends a pong. `data` is sent, `options` is an object with members `mask` and `binary`. `dontFailWhenClosed` indicates whether or not to throw if the connection isnt open.
+Sends a pong. `data` is sent, `options` is an object with members `mask` and `binary`. `dontFailWhenClosed` indicates whether or not to throw if the connection is not open.
 
 
 ### websocket.resume()
 
-Resume the client stream
+Resume the client stream.
 
 ### websocket.send(data, [options], [callback])
 
@@ -158,7 +162,7 @@ Streams data through calls to a user supplied function. `options` can be an obje
 
 ### websocket.terminate()
 
-Immediately shuts down the connection
+Immediately shuts down the connection.
 
 ### websocket.onopen
 ### websocket.onerror

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -559,7 +559,16 @@ function initAsClient(address, protocols, options) {
     }
   }
 
-  requestOptions.path = serverUrl.path || '/';
+  // ensure the path begins with '/'.'
+  if (serverUrl.pathname) {
+    requestOptions.path = serverUrl.path;
+  }
+  else if (serverUrl.path) {
+    requestOptions.path = '/' + serverUrl.path;
+  }
+  else {
+    requestOptions.path = '/';
+  }
 
   if (agent) {
     requestOptions.agent = agent;

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -72,7 +72,6 @@ function WebSocketServer(options, callback) {
       upgradeHead.copy(head);
 
       self.handleUpgrade(req, socket, head, function(client) {
-        self.emit('connection'+req.url, client);
         self.emit('connection', client);
       });
     });
@@ -137,7 +136,10 @@ WebSocketServer.prototype.handleUpgrade = function(req, socket, upgradeHead, cb)
   // check for wrong path
   if (this.options.path) {
     var u = url.parse(req.url);
-    if (u && u.pathname !== this.options.path) return;
+    if (u && u.pathname !== this.options.path) {
+      abortConnection(socket, 404, 'Path Not Found');
+      return;
+    }
   }
 
   if (typeof req.headers.upgrade === 'undefined' || req.headers.upgrade.toLowerCase() !== 'websocket') {

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -236,7 +236,12 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
 
     // signal upgrade complete
     socket.removeListener('error', errorHandler);
-    cb(client);
+
+    // Don't fire 'connection' event if any side of the connection was closed
+    // before reaching this point.
+    if (socket.readable && socket.writable) {
+      cb(client);
+    }
   }
 
   // optionally call external protocol selection handler before
@@ -299,7 +304,7 @@ function handleHixieUpgrade(req, socket, upgradeHead, cb) {
   }
   socket.on('error', errorHandler);
 
-  // bail if options prevent hixie
+  // fail if options prevent hixie
   if (this.options.disableHixie) {
     abortConnection(socket, 401, 'Hixie support disabled');
     return;
@@ -385,7 +390,12 @@ function handleHixieUpgrade(req, socket, upgradeHead, cb) {
 
           // signal upgrade complete
           socket.removeListener('error', errorHandler);
-          cb(client);
+
+          // Don't fire 'connection' event if any side of the connection was
+          // closed before reaching this point.
+          if (socket.readable && socket.writable) {
+            cb(client);
+          }
         });
       }
       catch (e) {

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -26,7 +26,6 @@ function WebSocketServer(options, callback) {
     server: null,
     verifyClient: null,
     handleProtocols: null,
-    path: null,
     noServer: false,
     disableHixie: false,
     clientTracking: true
@@ -48,17 +47,6 @@ function WebSocketServer(options, callback) {
   }
   else if (options.value.server) {
     this._server = options.value.server;
-    if (options.value.path) {
-      // take note of the path, to avoid collisions when multiple websocket servers are
-      // listening on the same http server
-      if (this._server._webSocketPaths && options.value.server._webSocketPaths[options.value.path]) {
-        throw new Error('two instances of WebSocketServer cannot listen on the same http server path');
-      }
-      if (typeof this._server._webSocketPaths !== 'object') {
-        this._server._webSocketPaths = {};
-      }
-      this._server._webSocketPaths[options.value.path] = 1;
-    }
   }
   if (this._server) this._server.once('listening', function() { self.emit('listening'); });
 
@@ -78,7 +66,6 @@ function WebSocketServer(options, callback) {
   }
 
   this.options = options.value;
-  this.path = options.value.path;
   this.clients = [];
 }
 
@@ -106,14 +93,6 @@ WebSocketServer.prototype.close = function() {
     error = e;
   }
 
-  // remove path descriptor, if any
-  if (this.path && this._server._webSocketPaths) {
-    delete this._server._webSocketPaths[this.path];
-    if (Object.keys(this._server._webSocketPaths).length == 0) {
-      delete this._server._webSocketPaths;
-    }
-  }
-
   // close the http server if it was internally created
   try {
     if (typeof this._closeServer !== 'undefined') {
@@ -133,15 +112,6 @@ WebSocketServer.prototype.close = function() {
  */
 
 WebSocketServer.prototype.handleUpgrade = function(req, socket, upgradeHead, cb) {
-  // check for wrong path
-  if (this.options.path) {
-    var u = url.parse(req.url);
-    if (u && u.pathname !== this.options.path) {
-      abortConnection(socket, 404, 'Path Not Found');
-      return;
-    }
-  }
-
   if (typeof req.headers.upgrade === 'undefined' || req.headers.upgrade.toLowerCase() !== 'websocket') {
     abortConnection(socket, 400, 'Bad Request');
     return;

--- a/test/WebSocketServer.test.js
+++ b/test/WebSocketServer.test.js
@@ -102,60 +102,6 @@ describe('WebSocketServer', function() {
         });
       });
     });
-
-    it('emits path specific connection event', function (done) {
-      var srv = http.createServer();
-      srv.listen(++port, function () {
-        var wss = new WebSocketServer({server: srv});
-        var ws = new WebSocket('ws://localhost:' + port+'/endpointName');
-
-        wss.on('connection/endpointName', function(client) {
-          wss.close();
-          srv.close();
-          done();
-        });
-      });
-    });
-
-    it('can have two different instances listening on the same http server with two different paths', function(done) {
-      var srv = http.createServer();
-      srv.listen(++port, function () {
-        var wss1 = new WebSocketServer({server: srv, path: '/wss1'})
-          , wss2 = new WebSocketServer({server: srv, path: '/wss2'});
-        var doneCount = 0;
-        wss1.on('connection', function(client) {
-          wss1.close();
-          if (++doneCount == 2) {
-            srv.close();
-            done();
-          }
-        });
-        wss2.on('connection', function(client) {
-          wss2.close();
-          if (++doneCount == 2) {
-            srv.close();
-            done();
-          }
-        });
-        var ws1 = new WebSocket('ws://localhost:' + port + '/wss1');
-        var ws2 = new WebSocket('ws://localhost:' + port + '/wss2?foo=1');
-      });
-    });
-
-    it('cannot have two different instances listening on the same http server with the same path', function(done) {
-      var srv = http.createServer();
-      srv.listen(++port, function () {
-        var wss1 = new WebSocketServer({server: srv, path: '/wss1'});
-        try {
-          var wss2 = new WebSocketServer({server: srv, path: '/wss1'});
-        }
-        catch (e) {
-          wss1.close();
-          srv.close();
-          done();
-        }
-      });
-    });
   });
 
   describe('#close', function() {
@@ -200,22 +146,6 @@ describe('WebSocketServer', function() {
           srv.close();
           done();
         });
-      });
-    });
-
-    it('cleans up websocket data on a precreated server', function(done) {
-      var srv = http.createServer();
-      srv.listen(++port, function () {
-        var wss1 = new WebSocketServer({server: srv, path: '/wss1'})
-          , wss2 = new WebSocketServer({server: srv, path: '/wss2'});
-        (typeof srv._webSocketPaths).should.eql('object');
-        Object.keys(srv._webSocketPaths).length.should.eql(2);
-        wss1.close();
-        Object.keys(srv._webSocketPaths).length.should.eql(1);
-        wss2.close();
-        (typeof srv._webSocketPaths).should.eql('undefined');
-        srv.close();
-        done();
       });
     });
   });


### PR DESCRIPTION
* Fix documentation: `http.ClientRequest` => `http.IncomingMessage` in `ws.Server.options.verifyClient`.
* Documentation: document `ws.WebSocket.upgradeReq`. 
* Don't emit 'connection' event if the socket was closed before the user calls `cb(true)` in the `verifyClient()` callback (note that the user may choose to call `cb(true)` after an asynchronous operation).