### PR TITLE
Fix error when compress option is true and perMessageDeflate is disabled

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -238,7 +238,10 @@ WebSocket.prototype.send = function send(data, options, cb) {
   }
 
   if (typeof options.mask === 'undefined') options.mask = !this._isServer;
-  if (typeof options.compress === 'undefined') options.compress = !!this.extensions[PerMessageDeflate.extensionName];
+  if (typeof options.compress === 'undefined') options.compress = true;
+  if (!this.extensions[PerMessageDeflate.extensionName]) {
+    options.compress = false;
+  }
 
   var readable = typeof stream.Readable === 'function'
     ? stream.Readable
@@ -291,7 +294,10 @@ WebSocket.prototype.stream = function stream(options, cb) {
   options = options || {};
 
   if (typeof options.mask === 'undefined') options.mask = !this._isServer;
-  if (typeof options.compress === 'undefined') options.compress = !!this.extensions[PerMessageDeflate.extensionName];
+  if (typeof options.compress === 'undefined') options.compress = true;
+  if (!this.extensions[PerMessageDeflate.extensionName]) {
+    options.compress = false;
+  }
 
   startQueue(this);
 

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -1897,6 +1897,28 @@ describe('WebSocket', function() {
       });
     });
 
+    describe('#send', function() {
+      it('can set the compress option true when perMessageDeflate is disabled', function(done) {
+        var wss = new WebSocketServer({port: ++port}, function() {
+          var ws = new WebSocket('ws://localhost:' + port, {perMessageDeflate: false});
+          ws.on('open', function() {
+            ws.send('hi', {compress: true});
+          });
+          ws.on('message', function(message, flags) {
+            assert.equal('hi', message);
+            ws.terminate();
+            wss.close();
+            done();
+          });
+        });
+        wss.on('connection', function(ws) {
+          ws.on('message', function(message, flags) {
+            ws.send(message, {compress: true});
+          });
+        });
+      });
+    });
+
     describe('#close', function() {
       it('should not raise error callback, if any, if called during send data', function(done) {
         var wss = new WebSocketServer({port: ++port, perMessageDeflate: true}, function() {


### PR DESCRIPTION
Sorry, I found a bug which happens when setting the `compress` option `true` explicitly.

```js
ws.send(data, { compress: true });

Uncaught TypeError: Cannot call method 'compress' of undefined
```
