### PR TITLE
Fix module registration

### DIFF
--- a/src/bufferutil.cc
+++ b/src/bufferutil.cc
@@ -107,7 +107,7 @@ protected:
   }
 };
 
-extern "C" void init (Handle<Object> target)
+void init (Handle<Object> target)
 {
   NanScope();
   BufferUtil::Initialize(target);

--- a/src/validation.cc
+++ b/src/validation.cc
@@ -135,7 +135,7 @@ protected:
   }
 };
 
-extern "C" void init (Handle<Object> target)
+void init (Handle<Object> target)
 {
   NanScope();
   Validation::Initialize(target);


### PR DESCRIPTION
ws passes an 'extern "C"' function to the NODE_MODULE macro.
The API docs at http://nodejs.org/api/addons.html DO NOT use 'extern
"C"'.
Removing 'extern "C"' causes the module to work properly on my system
(Ubuntu 14.04, 64bit, node v0.10.25).
Fixes #434