### PR TITLE
Make it work on nodejs v0.8 too

### DIFF
--- a/src/bufferutil.cc
+++ b/src/bufferutil.cc
@@ -6,6 +6,7 @@
 
 #include <v8.h>
 #include <node.h>
+#include <node_version.h>
 #include <node_buffer.h>
 #include <node_object_wrap.h>
 #include <stdlib.h>
@@ -107,6 +108,9 @@ protected:
   }
 };
 
+#if !NODE_VERSION_AT_LEAST(0,10,0)
+extern "C"
+#endif
 void init (Handle<Object> target)
 {
   NanScope();

--- a/src/validation.cc
+++ b/src/validation.cc
@@ -6,6 +6,7 @@
 
 #include <v8.h>
 #include <node.h>
+#include <node_version.h>
 #include <node_buffer.h>
 #include <node_object_wrap.h>
 #include <stdlib.h>
@@ -134,7 +135,9 @@ protected:
     NanReturnValue(is_valid_utf8(buffer_length, buffer_data) == 1 ? NanTrue() : NanFalse());
   }
 };
-
+#if !NODE_VERSION_AT_LEAST(0,10,0)
+extern "C"
+#endif
 void init (Handle<Object> target)
 {
   NanScope();


### PR DESCRIPTION
Do use 'extern "C"' for the module's init function if nodejs version is less than 0.10.0.
This fixes the travis test for nodejs v0.8.

###########################
Apologies for breaking the travis-ci test for nodejs v0.8 with my last pull request.
This one conditionally keeps the 'extern "C"' for older node releases.
Tests for both versions are green https://travis-ci.org/pjump/ws